### PR TITLE
Update app.js

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -495,8 +495,8 @@ app.plot = function() {
             }
         },
         yaxis: {
-            min: app.yMin * 0.95,
-            max: app.yMax * 1.05,
+            min: app.yMin - Math.abs(app.yMin)* 0.05,
+            max: app.yMax + Math.abs(app.yMax)* 0.05,
             showLabels: true,
             titleAngle: 90,
             title: app.readingTypeMap[app.readingType]['units'],


### PR DESCRIPTION
I was having trouble displaying negative electrical usage (associated with solar generation) for SCE data, and the problem was the graph drawing function munging the display when the usage data was negative and the yMin*0.95 reduced the bounds of the graph such that the data extended beyond the bounds... though strangely only if the negative data occurred within multiple days of the data set (a single day of negative usage data plotted just fine).  

This fix eliminates the errors associated with assuming that the usage data (max or min) are always positive or negative, and so the resulting grapher should work with a broader range of SCE customer data, and, in particular, better for customers with solar panels or other on-site power generation.